### PR TITLE
feat: navigate via directly paste github repo url

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -30,6 +30,18 @@ const onInputValUpdate = useDebounceFn(async (event: string) => {
     toast.add({ title: 'Error', description: String(error) })
   }
 }, 500)
+
+function onPaste(event: ClipboardEvent) {
+  const clipboardData = event.clipboardData
+  const clipboardText = clipboardData?.getData('text')
+
+  const regexp = /https:\/\/(?:www\.)?github\.com\/([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_\-\.]+)/
+
+  if (regexp.test(clipboardText)) {
+    const [, owner, name] = clipboardText.match(regexp) as RegExpMatchArray
+    navigateTo(`/${owner}/${name}`)
+  }
+}
 </script>
 
 <template>
@@ -50,6 +62,7 @@ const onInputValUpdate = useDebounceFn(async (event: string) => {
         placeholder="Search a GitHub repository …"
         size="xl"
         @update:model-value="onInputValUpdate"
+        @paste="onPaste"
       >
         <template #trailing>
           <UIcon name="i-radix-icons-magnifying-glass" />


### PR DESCRIPTION
This PR allows paste github repo URL into search input, and then directly navigate into its info page

![录屏2024-05-28 11 51 24](https://github.com/yuyinws/init-commit/assets/51878637/3d86d253-be79-4ac3-9901-05971994bdc3)
